### PR TITLE
Add end marker back to markdown

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -31,3 +31,4 @@ body:
         description: What version of pandarize did you use?
       validations:
         required: false
+---


### PR DESCRIPTION
The GH failed to recognize the markdown. Corrected by adding back the end marker (`---`). This PR attempts to resolve issue #16.